### PR TITLE
Add configurable sender selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,13 @@ go build
     --eth-rpc http://localhost:8545 \
     --private-key <private_key> \
     --num-distributors 10 \
+    --sender-selection round-robin \
     --data-rate 1000 \
 ```
+
+`--sender-selection` defaults to `random`. Use `round-robin` to rotate across
+configured sender accounts in order. It can also be set with
+`TX_OVERLOAD_SENDER_SELECTION`.
 
 More options are avaiable:
 ```

--- a/distributor.go
+++ b/distributor.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"math/rand"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -24,15 +23,22 @@ const txBufferSize = 3000
 var ErrQueueFull = errors.New("queue full")
 
 type Distributor struct {
-	m      *Metrics
-	root   *txmgr.SimpleTxManager
-	shards []Shard
-	client *ethclient.Client
-	logger log.Logger
-	cancel chan struct{}
+	m        *Metrics
+	root     *txmgr.SimpleTxManager
+	shards   []Shard
+	selector *senderSelector
+	client   *ethclient.Client
+	logger   log.Logger
+	cancel   chan struct{}
 }
 
-func NewDistributor(txmgrCfg txmgr.CLIConfig, l log.Logger, m *Metrics) (*Distributor, error) {
+type DistributorConfig struct {
+	TxManager       txmgr.CLIConfig
+	SenderSelection SenderSelection
+}
+
+func NewDistributor(config DistributorConfig, l log.Logger, m *Metrics) (*Distributor, error) {
+	txmgrCfg := config.TxManager
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	client, err := ethclient.DialContext(ctx, txmgrCfg.L1RPCURL)
@@ -75,12 +81,13 @@ func NewDistributor(txmgrCfg txmgr.CLIConfig, l log.Logger, m *Metrics) (*Distri
 	}
 
 	return &Distributor{
-		m:      m,
-		root:   root,
-		shards: shards,
-		client: client,
-		logger: l,
-		cancel: make(chan struct{}),
+		m:        m,
+		root:     root,
+		shards:   shards,
+		selector: newSenderSelector(config.SenderSelection),
+		client:   client,
+		logger:   l,
+		cancel:   make(chan struct{}),
 	}, nil
 }
 
@@ -97,7 +104,7 @@ func (d *Distributor) Stop() {
 }
 
 func (d *Distributor) Send(ctx context.Context, tx txmgr.TxCandidate) error {
-	shard := d.shards[rand.Intn(len(d.shards))]
+	shard := d.shards[d.selector.nextIndex(len(d.shards))]
 	select {
 	case shard.reqs <- tx:
 		d.m.RecordQueuedTx(&tx)

--- a/distributor_test.go
+++ b/distributor_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+)
+
+func TestDistributorSend_routes_through_sender_selector(t *testing.T) {
+	// Given
+	shards := []Shard{
+		{reqs: make(chan txmgr.TxCandidate, 1)},
+		{reqs: make(chan txmgr.TxCandidate, 1)},
+		{reqs: make(chan txmgr.TxCandidate, 1)},
+	}
+	distributor := &Distributor{
+		m:        NewMetrics(),
+		shards:   shards,
+		selector: newSenderSelector(SenderSelectionRoundRobin),
+	}
+
+	// When
+	for i := range shards {
+		candidate := txmgr.TxCandidate{TxData: []byte{byte(i)}}
+		if err := distributor.Send(context.Background(), candidate); err != nil {
+			t.Fatalf("Send(%d): %v", i, err)
+		}
+	}
+
+	// Then
+	for i, shard := range shards {
+		select {
+		case candidate := <-shard.reqs:
+			if len(candidate.TxData) != 1 || candidate.TxData[0] != byte(i) {
+				t.Fatalf("shard %d received data %v, want [%d]", i, candidate.TxData, i)
+			}
+		default:
+			t.Fatalf("shard %d received no candidate", i)
+		}
+	}
+}

--- a/flags.go
+++ b/flags.go
@@ -22,6 +22,12 @@ var (
 		Value:  "random",
 		EnvVar: opservice.PrefixEnvVar(envVarPrefix, "TX_MODE"),
 	}
+	SenderSelectionFlag = cli.StringFlag{
+		Name:   "sender-selection",
+		Usage:  "sender selection strategy. Valid values are 'random' and 'round-robin'.",
+		Value:  string(SenderSelectionRandom),
+		EnvVar: opservice.PrefixEnvVar(envVarPrefix, "SENDER_SELECTION"),
+	}
 	DataRateFlag = cli.Int64Flag{
 		Name:   "data-rate",
 		Usage:  "data rate in bytes per second.",
@@ -59,7 +65,7 @@ var (
 )
 
 func init() {
-	flags = append(flags, EthRpcFlag, TxModeFlag, DataRateFlag, NumDistributors, StartingIndex, BlockTimeFlag, TokenAddressFlag, Erc20GasLimitFlag)
+	flags = append(flags, EthRpcFlag, TxModeFlag, SenderSelectionFlag, DataRateFlag, NumDistributors, StartingIndex, BlockTimeFlag, TokenAddressFlag, Erc20GasLimitFlag)
 	flags = append(flags, oplog.CLIFlags(envVarPrefix)...)
 	flags = append(flags, txmgr.CLIFlags(envVarPrefix)...)
 	flags = append(flags, opmetrics.CLIFlags(envVarPrefix)...)

--- a/main.go
+++ b/main.go
@@ -213,6 +213,10 @@ func Main(cliCtx *cli.Context) error {
 	distributors = keys[startingIndex : startingIndex+numDistributors]
 
 	blockTimeMs := cliCtx.GlobalInt(BlockTimeFlag.Name)
+	senderSelection, err := parseSenderSelection(cliCtx.GlobalString(SenderSelectionFlag.Name))
+	if err != nil {
+		return err
+	}
 
 	// Rejected up front rather than silently zero-padded by HexToAddress, which
 	// would send every erc20 transfer to a garbage contract.
@@ -232,7 +236,10 @@ func Main(cliCtx *cli.Context) error {
 		}()
 	}
 
-	distributor, err := NewDistributor(txmgrCfg, logger, m)
+	distributor, err := NewDistributor(DistributorConfig{
+		TxManager:       txmgrCfg,
+		SenderSelection: senderSelection,
+	}, logger, m)
 	if err != nil {
 		return err
 	}

--- a/sender_selection.go
+++ b/sender_selection.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"sync/atomic"
+)
+
+type SenderSelection string
+
+const (
+	SenderSelectionRandom     SenderSelection = "random"
+	SenderSelectionRoundRobin SenderSelection = "round-robin"
+)
+
+func parseSenderSelection(raw string) (SenderSelection, error) {
+	switch SenderSelection(raw) {
+	case SenderSelectionRandom:
+		return SenderSelectionRandom, nil
+	case SenderSelectionRoundRobin:
+		return SenderSelectionRoundRobin, nil
+	default:
+		return "", fmt.Errorf("invalid --sender-selection value %q: must be random or round-robin", raw)
+	}
+}
+
+type senderSelector struct {
+	selection SenderSelection
+	next      atomic.Uint64
+}
+
+func newSenderSelector(selection SenderSelection) *senderSelector {
+	return &senderSelector{selection: selection}
+}
+
+func (s *senderSelector) nextIndex(shardCount int) int {
+	switch s.selection {
+	case SenderSelectionRandom:
+		return rand.Intn(shardCount)
+	case SenderSelectionRoundRobin:
+		return int((s.next.Add(1) - 1) % uint64(shardCount))
+	default:
+		panic(fmt.Sprintf("unsupported sender selection %q", s.selection))
+	}
+}

--- a/sender_selection_test.go
+++ b/sender_selection_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestParseSenderSelection_accepts_supported_values(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want SenderSelection
+	}{
+		{name: "random", raw: "random", want: SenderSelectionRandom},
+		{name: "round robin", raw: "round-robin", want: SenderSelectionRoundRobin},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			raw := tt.raw
+
+			// When
+			got, err := parseSenderSelection(raw)
+
+			// Then
+			if err != nil {
+				t.Fatalf("parseSenderSelection(%q): %v", raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseSenderSelection(%q) = %q, want %q", raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSenderSelection_rejects_unsupported_value(t *testing.T) {
+	// Given
+	raw := "first"
+
+	// When
+	_, err := parseSenderSelection(raw)
+
+	// Then
+	if err == nil {
+		t.Fatal("parseSenderSelection returned nil error")
+	}
+	if !strings.Contains(err.Error(), "invalid --sender-selection") || !strings.Contains(err.Error(), raw) {
+		t.Fatalf("parseSenderSelection error = %q, want flag name and invalid value", err)
+	}
+}
+
+func TestSenderSelectionFlag_defaults_to_random_and_uses_prefixed_environment(t *testing.T) {
+	// Given
+	wantDefault := string(SenderSelectionRandom)
+	wantEnvVar := "TX_OVERLOAD_SENDER_SELECTION"
+
+	// When
+	gotDefault := SenderSelectionFlag.Value
+	gotEnvVar := SenderSelectionFlag.EnvVar
+
+	// Then
+	if gotDefault != wantDefault {
+		t.Fatalf("SenderSelectionFlag.Value = %q, want %q", gotDefault, wantDefault)
+	}
+	if gotEnvVar != wantEnvVar {
+		t.Fatalf("SenderSelectionFlag.EnvVar = %q, want %q", gotEnvVar, wantEnvVar)
+	}
+}
+
+func TestSenderSelector_round_robin_wraps_deterministically(t *testing.T) {
+	// Given
+	selector := newSenderSelector(SenderSelectionRoundRobin)
+	want := []int{0, 1, 2, 0, 1}
+	got := make([]int, len(want))
+
+	// When
+	for i := range got {
+		got[i] = selector.nextIndex(3)
+	}
+
+	// Then
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("selection %d = %d, want %d; all selections: %v", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestSenderSelector_round_robin_is_safe_for_concurrent_callers(t *testing.T) {
+	// Given
+	const (
+		shardCount = 4
+		callCount  = 64
+	)
+	selector := newSenderSelector(SenderSelectionRoundRobin)
+	selected := make(chan int, callCount)
+	var callers sync.WaitGroup
+	callers.Add(callCount)
+
+	// When
+	for i := 0; i < callCount; i++ {
+		go func() {
+			defer callers.Done()
+			selected <- selector.nextIndex(shardCount)
+		}()
+	}
+	callers.Wait()
+	close(selected)
+
+	// Then
+	counts := make([]int, shardCount)
+	for index := range selected {
+		counts[index]++
+	}
+	for index, count := range counts {
+		if count != callCount/shardCount {
+			t.Fatalf("index %d selected %d times, want %d; all counts: %v", index, count, callCount/shardCount, counts)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a `--sender-selection` flag with the existing random routing as the default
- add a concurrency-safe `round-robin` option that rotates queued transactions across configured sender accounts
- document the flag and its `TX_OVERLOAD_SENDER_SELECTION` environment variable

## Testing
- `gofmt -l distributor.go distributor_test.go flags.go main.go sender_selection.go sender_selection_test.go`
- `go vet ./...`
- `go test -race -shuffle=on -count=1 ./...`
- `go build -o <temporary-output> .`
- `go run . --help`