### PR TITLE
Publish sha-tagged images for master merges

### DIFF
--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -1,0 +1,41 @@
+---
+name: Release Optimism tx-overload Container
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  resolve-tag:
+    name: Resolve short commit sha
+    runs-on: ubuntu-24.04
+    outputs:
+      short-sha: ${{ steps.short-sha.outputs.value }}
+    steps:
+      - name: Shorten the commit sha
+        id: short-sha
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+        run: echo "value=${COMMIT_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+  release-container-op-tx-overload:
+    needs: resolve-tag
+    uses: celo-org/reusable-workflows/.github/workflows/docker-build.yaml@v3.1.1
+    name: Release Optimism tx-overload image container
+    permissions:
+      actions: read
+      attestations: write
+      contents: write
+      id-token: write
+      pull-requests: write
+      security-events: write
+    with:
+      artifact-registry: us-west1-docker.pkg.dev/devopsre/dev-images/tx-overload
+      tags: sha-${{ needs.resolve-tag.outputs.short-sha }}
+      platforms: linux/amd64
+      workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-tx-overload/providers/github-by-repos
+      service-account: tx-overload@devopsre.iam.gserviceaccount.com
+      context: .
+      file: Dockerfile
+      trivy-enabled: false


### PR DESCRIPTION
## Summary
- add a release workflow that publishes `sha-<short_git_hash>` on every merge to `master`
- build through `reusable-workflows` v3.1.1, which attaches a SLSA provenance attestation

## Why
The existing workflow only pushes the mutable `test` tag, so each master build overwrites the previous one and deployments cannot pin an immutable reference.

The v3.1.1 pipeline also runs `actions/attest-build-provenance`. Images built by the current `container-cicd.yaml@v2.0.4` path are only cosign-signed, and the clusters' `devopsre-images-signed` policy rejects them at admission with `no valid bundles exist in registry`.

## Note
`build-container.yaml` still triggers on `master` and publishes `test` via v2.0.4, so both workflows will run on a merge. Happy to retire its `master` trigger (leaving `workflow_dispatch`) or migrate it to v3.1.1 in a follow-up — say which you prefer.